### PR TITLE
add support for scrolling within a scrollable container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+node_modules
 components
 build

--- a/example-container.html
+++ b/example-container.html
@@ -1,0 +1,66 @@
+<html>
+<head>
+  <title>scroll-to - smooth javascript window scrolling with requestAnimationFrame</title>
+  <style>
+    body {
+      padding: 50px;
+      overflow: hidden;
+    }
+
+    div {
+      position: relative;
+      overflow: auto;
+      width: 500px;
+      height: 300px;
+    }
+
+    ul {
+      min-width: 1500px;
+      overflow: hidden;
+    }
+
+    ul li {
+      margin: 10px;
+      padding: 5px;
+      list-style: none;
+      display: block;
+      float: left;
+      width: 100px;
+      height: 100px;
+      border: 1px solid #eee;
+      text-align: center;
+      line-height: 100px;
+    }
+  </style>
+</head>
+<body>
+  <div><ul></ul></div>
+
+  <script src="build/build.js"></script>
+
+  <script>
+    var scroll = require('scroll-to');
+    var events = require('event');
+    var ul = document.querySelector('ul');
+
+    for (var i = 0; i < 500; i++) {
+      var li = document.createElement('li');
+      li.textContent = 'item ' + i;
+      ul.appendChild(li);
+    }
+
+    var options = {
+      container: document.querySelector('div')
+    }
+
+    ul.addEventListener('click', function (e) {
+      var li = e.target
+      var x = li.offsetLeft
+      var y = li.offsetTop
+
+      console.log('scrolling to (%s, %s)', x, y);
+      scroll(x, y, options);
+    })
+  </script>
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function scrollTo(x, y, options) {
   options = options || {};
 
   // start position
-  var start = scroll();
+  var start = scroll(options);
 
   // setup tween
   var tween = Tween(start)
@@ -31,10 +31,17 @@ function scrollTo(x, y, options) {
     .to({ top: y, left: x })
     .duration(options.duration || 1000);
 
+  var updateScroll = options.container
+    ? function (o) {
+      options.container.scrollTop = o.top | 0;
+      options.container.scrollLeft = o.left | 0;
+    }
+    : function (o) {
+      window.scrollTo(o.left | 0, o.top | 0);
+    }
+
   // scroll
-  tween.update(function(o){
-    window.scrollTo(o.left | 0, o.top | 0);
-  });
+  tween.update(updateScroll);
 
   // handle end
   tween.on('end', function(){
@@ -48,7 +55,7 @@ function scrollTo(x, y, options) {
   }
 
   animate();
-  
+
   return tween;
 }
 
@@ -59,8 +66,12 @@ function scrollTo(x, y, options) {
  * @api private
  */
 
-function scroll() {
-  var y = window.pageYOffset || document.documentElement.scrollTop;
-  var x = window.pageXOffset || document.documentElement.scrollLeft;
+function scroll(options) {
+  var y = options.container
+          ? options.container.scrollTop
+          : window.pageYOffset || document.documentElement.scrollTop;
+  var x = options.container
+          ? options.container.scrollLeft
+          : window.pageXOffset || document.documentElement.scrollLeft;
   return { top: y, left: x };
 }


### PR DESCRIPTION
`scroll-to` is a great module but it only has support for scrolling the `window`. I came across a case where I need to smooth scroll to an element within a scrollable container. Which is why I raised this PR.

Let me know your thoughts.